### PR TITLE
Improve the links on club info pages

### DIFF
--- a/scripts/listDomains.js
+++ b/scripts/listDomains.js
@@ -1,0 +1,36 @@
+const fs = require('fs/promises');
+
+if (process.argv.length !== 3) {
+  console.log(`usage: ${process.argv[0]} ${process.argv[1]} <path to input json>`);
+  process.exit(1);
+}
+
+const [, , inputFilePath] = process.argv;
+
+async function main() {
+  const originalBytes = (await fs.readFile(inputFilePath)).buffer;
+  const originalString = new Buffer.from(originalBytes).toString();
+  const originalJSON = JSON.parse(originalString);
+
+  const domainMap = new Map();
+
+  originalJSON.forEach((club) => {
+    club.socialMedia
+      .filter((s) => s !== '')
+      .forEach((s) => {
+        const url = new URL(s);
+        const domain = url.hostname.replace(/^www\./, '');
+        if (domainMap.has(domain)) {
+          domainMap.set(domain, domainMap.get(domain) + 1);
+        } else {
+          domainMap.set(domain, 1);
+        }
+      });
+    console.log(club);
+  });
+
+  console.log(domainMap);
+  return;
+}
+
+main();

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@chakra-ui/react';
-import { IoMdLink } from 'react-icons/io';
+import { IconType } from 'react-icons';
+import { FaDiscord, FaFacebook, FaInstagram, FaLink } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import Icon from './Icon';
@@ -23,11 +24,24 @@ function simplifyURL(url: string) {
   return url.replace(urlStart, '').replace(urlQueries, '');
 }
 
+function getIcon(url: string): IconType {
+  const defaultIcon: IconType = FaLink;
+  const urlMap: { [key: string]: IconType } = {
+    'facebook.com': FaFacebook,
+    'instagram.com': FaInstagram,
+    'discord.gg': FaDiscord,
+  };
+
+  const domain = new URL(url).hostname.replace(/^www\./, '');
+
+  return urlMap[domain] ?? defaultIcon;
+}
+
 function LinkItem(props: { link: string }) {
   return (
     <Button size="sm" style={{ maxWidth: '100%' }}>
       <a href={props.link} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-        <Icon icon={IoMdLink}></Icon>
+        <Icon icon={getIcon(props.link)}></Icon>
         {simplifyURL(props.link)}
       </a>
     </Button>

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -51,6 +51,7 @@ function LinkItem(props: { link: string }) {
         whiteSpace: 'nowrap',
         fontSize: '0.9em',
         textDecoration: 'underline',
+        padding: '0.05em 0',
       }}
     >
       <Icon icon={getIcon(props.link)}></Icon>

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -25,8 +25,8 @@ function simplifyURL(url: string) {
 
 function LinkItem(props: { link: string }) {
   return (
-    <Button size="sm">
-      <a href={props.link}>
+    <Button size="sm" style={{ maxWidth: '100%' }}>
+      <a href={props.link} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         <Icon icon={IoMdLink}></Icon>
         {simplifyURL(props.link)}
       </a>

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@chakra-ui/react';
-import { IoMdLink } from 'react-icons/io';
+import { IconType } from 'react-icons';
+import { FaDiscord, FaFacebook, FaInstagram, FaLink } from 'react-icons/fa';
 import styled from 'styled-components';
 
 import Icon from './Icon';
@@ -23,11 +24,27 @@ function simplifyURL(url: string) {
   return url.replace(urlStart, '').replace(urlQueries, '');
 }
 
+function getIcon(url: string): IconType {
+  const defaultIcon: IconType = FaLink;
+  const urlMap: { [key: string]: IconType } = {
+    'facebook.com': FaFacebook,
+    'instagram.com': FaInstagram,
+    'discord.gg': FaDiscord,
+  };
+
+  const domain = new URL(url).hostname.replace(/^www\./, '');
+
+  return urlMap[domain] ?? defaultIcon;
+}
+
 function LinkItem(props: { link: string }) {
   return (
     <Button size="sm" style={{ maxWidth: '100%' }}>
-      <a href={props.link} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-        <Icon icon={IoMdLink}></Icon>
+      <a
+        href={props.link}
+        style={{ overflow: 'hidden', textOverflow: 'ellipsis', display: 'flex', alignItems: 'center' }}
+      >
+        <Icon icon={getIcon(props.link)}></Icon>
         {simplifyURL(props.link)}
       </a>
     </Button>

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -19,9 +19,10 @@ const LinkListDiv = styled.ul`
 
 const urlStart = /^https?:\/\/(www\.)?/;
 const urlQueries = /\?.*$/;
+const trailingSlash = /\/$/;
 
 function simplifyURL(url: string) {
-  return url.replace(urlStart, '').replace(urlQueries, '');
+  return url.replace(urlStart, '').replace(urlQueries, '').replace(trailingSlash, '');
 }
 
 function getIcon(url: string): IconType {

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@chakra-ui/react';
 import { IoMdLink } from 'react-icons/io';
 import styled from 'styled-components';
 
@@ -10,16 +11,26 @@ const LinkListDiv = styled.ul`
     margin-left: 0;
     margin-bottom: 10px;
   }
+  overflow: auto;
   margin-top: 20px;
   margin-left: 15%;
 `;
 
+const urlStart = /^https?:\/\/(www\.)?/;
+const urlQueries = /\?.*$/;
+
+function simplifyURL(url: string) {
+  return url.replace(urlStart, '').replace(urlQueries, '');
+}
+
 function LinkItem(props: { link: string }) {
   return (
-    <div>
-      <Icon icon={IoMdLink}></Icon>
-      <p>{props.link}</p>
-    </div>
+    <Button size="sm">
+      <a href={props.link}>
+        <Icon icon={IoMdLink}></Icon>
+        {simplifyURL(props.link)}
+      </a>
+    </Button>
   );
 }
 
@@ -27,9 +38,11 @@ function LinkList(props: { links: string[] }) {
   return (
     <LinkListDiv>
       <ul className="link-list">
-        {props.links.map((link) => {
-          return <LinkItem link={link} />;
-        })}
+        {props.links
+          .filter((s) => s !== '')
+          .map((link) => (
+            <LinkItem link={link} />
+          ))}
       </ul>
     </LinkListDiv>
   );

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -40,9 +40,17 @@ function getIcon(url: string): IconType {
 function LinkItem(props: { link: string }) {
   return (
     <Button size="sm" style={{ maxWidth: '100%' }}>
-      <a href={props.link} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+      <a
+        href={props.link}
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
         <Icon icon={getIcon(props.link)}></Icon>
-        {simplifyURL(props.link)}
+        <span style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{simplifyURL(props.link)}</span>
       </a>
     </Button>
   );

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -42,6 +42,7 @@ function LinkItem(props: { link: string }) {
   return (
     <a
       href={props.link}
+      target="_blank"
       style={{
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/src/ClubInfo/Links.tsx
+++ b/src/ClubInfo/Links.tsx
@@ -40,20 +40,21 @@ function getIcon(url: string): IconType {
 
 function LinkItem(props: { link: string }) {
   return (
-    <Button size="sm" style={{ maxWidth: '100%' }}>
-      <a
-        href={props.link}
-        style={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          display: 'flex',
-          alignItems: 'center',
-        }}
-      >
-        <Icon icon={getIcon(props.link)}></Icon>
-        <span style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{simplifyURL(props.link)}</span>
-      </a>
-    </Button>
+    <a
+      href={props.link}
+      style={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        display: 'flex',
+        alignItems: 'center',
+        whiteSpace: 'nowrap',
+        fontSize: '0.9em',
+        textDecoration: 'underline',
+      }}
+    >
+      <Icon icon={getIcon(props.link)}></Icon>
+      <span style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{simplifyURL(props.link)}</span>
+    </a>
   );
 }
 

--- a/src/JSON/ClubData.json
+++ b/src/JSON/ClubData.json
@@ -984,7 +984,12 @@
     "name": "VikeLabs",
     "category": "stem",
     "primaryEmail": "vikelabs@gmail.com",
-    "socialMedia": ["https://www.vikelabs.ca"],
+    "socialMedia": [
+      "https://www.vikelabs.ca",
+      "https://www.instagram.com/vikelabs/",
+      "https://www.facebook.com/VikeLabs",
+      "https://discord.gg/AWcEfYKjff"
+    ],
     "tags": ["STEM"],
     "description": "VikeLabs is a collective of students who learn to build, deploy, and test software quickly. We view UVic as a kind of laboratory for testing solutions to problems that exist within the UVic community. We limit ourselves to the UVic community because it's much easier to deploy and test solutions to users where we are in close proximity to them and their problems. Feel free to reach out.",
     "slug": "vikelabs"


### PR DESCRIPTION
This PR addresses issue #35 by overhauling the appearance of links as buttons with the url and an icon, and by making them interactive as hyperlinks. 

Here are some examples:

Facebook link
![image](https://user-images.githubusercontent.com/56709101/132805896-5f93839e-4667-4d0b-963b-092be7b665a5.png)

Instagram link
![image](https://user-images.githubusercontent.com/56709101/132805923-13fd1657-015c-4b18-8720-98bb6fbfa6a1.png)

Discord link
![image](https://user-images.githubusercontent.com/56709101/132805963-cea1a76d-29f0-4d16-9a57-90e71034ae46.png)

Miscellaneous link
![image](https://user-images.githubusercontent.com/56709101/132806043-96cc7fee-fe4e-46fe-a727-f4d905278b3b.png)

The button is from the Chakra UI React library, and the icons are from Font Awesome throught the React Icons library, both which were in the project already.